### PR TITLE
Configuration max_instances was being ignored - fix

### DIFF
--- a/include/classes/Octave_daemon.php
+++ b/include/classes/Octave_daemon.php
@@ -214,7 +214,7 @@ class Octave_daemon
 
 				Octave_pool::manageConnections();
 			}
-			usleep(100);
+			usleep(1000);
 		}
 
 	}


### PR DESCRIPTION
The Global Configuration "max_instances" was ignored when launching children processes - octave-daemon would always launch 3. Fix for that.
