### PR TITLE
Octave 4 compatibility

### DIFF
--- a/include/classes/Octave_controller.php
+++ b/include/classes/Octave_controller.php
@@ -72,7 +72,7 @@ class Octave_controller extends Octave_partial_processor
 	*
 	* @var array
 	*/
-	public $octave_options=array("--no-window-system");
+	public $octave_options=array("--no-window-system", "--no-gui", "--no-gui-libs");
 
 	/**
 	* The Octave binary version.


### PR DESCRIPTION
Had to add more options, so it works with octave 4.

Ref: https://www.gnu.org/software/octave/NEWS-4.0.html

Should fix #20
